### PR TITLE
Update sherpaX and add ciao-sherpa.cfg to supply dependencies

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -100,6 +100,7 @@ sherpa:
 	./install.py $(STDCONF) --config sherpa.cfg 
 
 sherpaX:
+	./install.py $(STDCONF) --config ciao-sherpa.cfg
 	./install.py $(STDCONF) --config sherpaX.cfg 
 
 # Optional packages for python modules

--- a/cfg/ciao-sherpa.cfg
+++ b/cfg/ciao-sherpa.cfg
@@ -1,0 +1,35 @@
+##############################################################################
+# Minimal subset of CIAO to build standalone sherpaX
+#
+# See http://www.astropython.org/tutorial/2010/1/Installing-Sherpa-standalone-for-X-ray-analysis
+#
+# ciao-sherpa-4.4.tar.gz was made by manually inspecting the sherpa make
+# instructions and copying files into ciao/... until sherpaX would build
+# and pass tests.  The ciao/include directory was copied in its entirety.
+#   tar zcf ciao-sherpa-4.4.tar.gz ciao
+#
+# There is a soft link ciao/ots/spectral -> /soft/ciao-4.4/ots/spectral.  This
+# points to a 328M directory that is available on HEAD for X-ray analysis.
+# On GRETA this will be unresolved but should not impact any FOT use of sherpa.
+
+---
+content : ciao-sherpa
+autofile:      # define RE transforms to get from name to tarfile glob
+  - in : '$'
+    out: '*'
+
+
+modules:
+  - name : ciao-sherpa
+    cmds :
+      test : |
+        test -e .installed
+        test -e ${prefix_arch}/ciao/lib/libgrp.so
+        test -e ${prefix_arch}/ciao/lib/liberr.so
+        test -e ${prefix_arch}/ciao/lib/libregion.so
+        test -e ${prefix_arch}/ciao/lib/libascdm.so
+        test -e ${prefix_arch}/ciao/ots/lib/libcfitsio.so
+
+      install : |
+        rsync -av ./  ${prefix_arch}/ciao/
+        touch .installed

--- a/cfg/sherpaX.cfg
+++ b/cfg/sherpaX.cfg
@@ -3,8 +3,15 @@
 #
 # See http://www.astropython.org/tutorial/2010/1/Installing-Sherpa-standalone-for-X-ray-analysis
 # 
-# NOTE: need to make a link from appropriate CIAO installation to ${prefix_arch}/ciao
+# NOTE: needs to have ciao-sherpa.cfg installed first
 #
+# TEST:
+#   import sherpa.astro.ui as ui
+#   ui.load_pha('/home/aldcroft/Science/ACIS_bgd/2010/acis2s.pi')
+#   ui.set_source(ui.xsphabs.abs1 * ui.powlaw1d.p1)
+#   ui.fit()
+#   ui.plot_fit_resid()
+
 --- 
 content : sherpa modules
 autofile:      # define RE transforms to get from name to tarfile glob
@@ -18,6 +25,7 @@ modules:
       test : |
         test -e .installed
         cd $prefix
+        export HEADAS=${prefix_arch}/ciao/ots/spectral
         ${prefix_arch}/bin/python -c "import sherpa.ui"
         ${prefix_arch}/bin/python -c "import sherpa.astro.ui"
       install : |
@@ -25,8 +33,9 @@ modules:
         export F90=/usr/bin/gfortran
         export F77=/usr/bin/gfortran
         
-        cp -fp ${prefix_arch}/ciao/lib/python2.6/site-packages/group.so \
-               ${prefix_arch}/lib/python2.6/site-packages/
+        cp -fp ${prefix_arch}/ciao/lib/python2.7/site-packages/group.so \
+               ${prefix_arch}/lib/python2.7/site-packages/
+        cp -fp ${prefix_arch}/ciao/lib/libgrp.so ${prefix_arch}/lib/
         cp -fp ${prefix_arch}/ciao/lib/liberr.so ${prefix_arch}/lib/
         cp -fp ${prefix_arch}/ciao/lib/libregion.so ${prefix_arch}/lib/
         cp -fp ${prefix_arch}/ciao/lib/libascdm.so ${prefix_arch}/lib/
@@ -42,7 +51,7 @@ modules:
         fi
         
         ${prefix_arch}/bin/python setup.py \
-          fftw_library_dir=${prefix_arch}/ciao/ots/lib \
+          fftw_library_dir=${prefix_arch}/ciao/lib \
           fftw_include_dir=${prefix_arch}/ciao/ots/include \
           cfitsio_library_dir=${prefix_arch}/ciao/ots/lib \
           xspec_library_dir=${prefix_arch}/ciao/ots/lib \
@@ -51,6 +60,6 @@ modules:
           wcs_library_dir=${prefix_arch}/ciao/ots/lib \
           wcs_include_dir=${prefix_arch}/ciao/ots/include \
           fortran_lib=gfortran \
-          fortran_library_dir=${prefix_arch}/ciao/lib \
+          fortran_library_dir=${prefix_arch}/lib \
           install
         touch .installed

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -39,7 +39,7 @@ PyYAML-3.10.tar.gz
 pyzmq-2.1.11.tar.gz
 Quaternion-0.03.2.tar.gz
 scipy-0.10.1.tar.gz
-sherpa-4.3.0.tar.gz
+sherpa-4.4.1.tar.gz
 sip-4.13.1.tar.gz
 Ska.arc5gl-0.01.tar.gz
 Ska.astro-0.02.tar.gz
@@ -103,6 +103,7 @@ swig-1.3.40.tar.gz
 zeromq-2.1.11.tar.gz
 #
 # Numerical libraries
+ciao-sherpa-4.4.tar.gz
 hdf5-1.8.7.tar.gz
 boost_1_39_0.tar.gz
 fftw-3.2.1.tar.gz


### PR DESCRIPTION
Update sherpaX so that it installs using the locally supplied
ciao-sherpa-4.4.tar.gz package.  This supplies the files that
standalone sherpa 4.4 needs to build and run, EXCEPT for
the full XSPEC models, which are now supplied as a soft link
to the current HEAD LAN installation of CIAO 4.4.
