### PR TITLE
Update pgplot to 5.2.2-3_05

### DIFF
--- a/cfg/pgplot.cfg
+++ b/cfg/pgplot.cfg
@@ -10,40 +10,23 @@ cmds :
     cd ${PGPLOT_DIR}
     test -e libpgplot.a
     test -e libcpgplot.a
-    test -e cpgdemo
     test -e cpgplot.h
+  build : |
+    ./configure --prefix ${module_dir}/build
+    make
+    # this just installs it in the build directory
+    make install
   install : |
     echo ${PGPLOT_DIR}
     if [ -e ${PGPLOT_DIR} ] ; then
       rm -r ${PGPLOT_DIR}
     fi
     mkdir -p ${PGPLOT_DIR}
-    cd ${PGPLOT_DIR}
-    cp -p ${module_dir}/drivers.list drivers.list
-    if test ! -e /usr/lib64 ; then  # No GIF for 32-bit build
-      perl -i.bak -pe 's{ GIDRIV}{! GIDRIV}' drivers.list
-    fi
-    perl -i.bak -pe 's{! PNDRIV}{ PNDRIV}' drivers.list
-
-    ${module_dir}/makemake $module_dir linux g77_gcc
-    if test -e /usr/lib64 ; then
-       perl -i.bak -pe 's{-L/usr/X11R6/lib}{-L/usr/X11R6/lib -L/usr/X11R6/lib64}g' makefile
-       perl -i.bak -pe 's{INTEGER PIXMAP, WORK}{INTEGER*8 PIXMAP, WORK}' ${module_dir}/drivers/gidriv.f
-    fi
-    # gfortran does seem to have fewer problems and makes GIDRIV on
-    # CentOS 6 (gfortran > 4.3), so only use g77 on old 64-bit build
-    if [ "$platform_os_generic" != "x86_64-linux_CentOS-5" ]; then
-       perl -i.bak -pe 's{FCOMPL=g77}{FCOMPL=gfortran}' makefile
-       perl -i.bak -pe 's{FFLAGC=}{FFLAGC=-ffixed-form -ffixed-line-length-none }' makefile
-    fi
-    perl -i.bak -pe 's{XINCL=}{XINCL=-I\$(SKA_ARCH_OS)/include }' makefile
-    perl -i.bak -pe 's{LIBS=}{LIBS=-L\$(SKA_ARCH_OS)/lib }' makefile
-    perl -i.bak -pe 's{TK_INCL=}{TK_INCL=-I\$(SKA_ARCH_OS)/include }' makefile
-    perl -i.bak -pe 's{TK_LIBS=}{TK_LIBS=-L\$(SKA_ARCH_OS)/lib }' makefile
-    perl -i.bak -pe 's{pndriv.o :.+}{pndriv.o :}' makefile
-    make
-    make cpg
-    rm *.o
+    cp -p ${module_dir}/build/lib/lib* ${PGPLOT_DIR}
+    cp -p ${module_dir}/build/bin/* ${PGPLOT_DIR}
+    cp -p ${module_dir}/build/include/pgplot/cpgplot.h ${PGPLOT_DIR}
+    cp -p ${module_dir}/build/libexec/pgplot/grfont.dat ${PGPLOT_DIR}
+    cp -p ${module_dir}/build/libexec/pgplot/rgb.txt ${PGPLOT_DIR}
     touch ${module_dir}/.installed
 
 modules :

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -209,7 +209,7 @@ PAR-Dist-0.07.tar.gz
 ParseTable-1.4.tar.gz
 PDL-2.4.4_patch.tar.gz
 PGPLOT-2.19_patch.tar.gz
-pgplot.tar.gz
+pgplot-5.2.2-3_05.tar.gz
 plplot-5.6.1.tar.gz
 Pod-Help-1.00.tar.gz
 RDB-1.43.tar.gz


### PR DESCRIPTION
pgplot 5.2.2-3_05 is a recent tarball of Diab's auto-tooled pgplot.
This tarball includes a bugfix from Pete Ratzlaff on the pgplot PNG
driver that appears to fix intermittent plot failures.
