### PR TITLE
Add libg2c_bin package at version 0.0.0

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -16,7 +16,7 @@ all_64: basedirs libs python_64 perl std_extras
 basedirs:
 	./install.py --prefix $(PREFIX) --no-env-vars --config template
 
-libs: xtime wcstools cfitsio pgplot gsl hdf5 expat libyaml mpich2 gtk num_libs_bin zmq
+libs: xtime wcstools cfitsio libg2c_bin pgplot gsl hdf5 expat libyaml mpich2 gtk num_libs_bin zmq
 
 python_32: activepython_32 libpython_so32 num_sci_src swig pygtk python_modules
 
@@ -71,6 +71,9 @@ libmysql:
 
 num_libs_bin:
 	./install.py $(STDCONF) --config num_libs_bin
+
+libg2c_bin:
+	./install.py $(STDCONF) --config libg2c_bin
 
 expat:
 	./install.py $(STDCONF) --config expat

--- a/cfg/libg2c_bin.cfg
+++ b/cfg/libg2c_bin.cfg
@@ -1,0 +1,31 @@
+##############################################################################
+# g2c libs copied from unagi (64bit) and quango (32bit) CentOS 5
+#
+--- 
+content : libg2c_bin
+
+cmds : 
+  test : |
+    test -e .installed
+    test -e ${prefix_arch}/lib/libg2c.so.0
+
+  install : |
+    cp ${platform_os_generic}/* ${prefix_arch}/lib/
+    touch .installed
+
+modules :
+  - name : libg2c_bin
+    file : libg2c_bin-*
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -112,6 +112,7 @@ libpython_so32-2.7.tar.gz
 #
 # Misc supporting C libraries
 # 
+libg2c_bin-0.0.0.tar.gz
 mpich2-1.4.tar.gz
 yaml-0.1.4.tar.gz
 swig-1.3.40.tar.gz


### PR DESCRIPTION
This adds libg2c bin libs packaged from quango (32bit) and unagi
(64bit) CentOS5 systems.  This is for CentOS5 PGPLOT compatibility.
