### PR TITLE
Update Ska-Web to 0.03 from 0.02

### DIFF
--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -241,7 +241,7 @@ Ska-Message-0.01.tar.gz
 Ska-Process-0.04.tar.gz
 Ska-RDB-0.03.tar.gz
 Ska-Run-0.02.tar.gz
-Ska-Web-0.02.tar.gz
+Ska-Web-0.03.tar.gz
 Sub-Uplevel-0.24.tar.gz
 Test-Exception-0.32.tar.gz
 Test-Simple-1.001002.tar.gz


### PR DESCRIPTION
Update Ska-Web to 0.03 from 0.02

This update to Ska-Web saves remote timestamps for fetched files.