### PR TITLE
Update CXC-Envs-Flight from 1.99 to 2.01

### DIFF
--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -169,7 +169,7 @@ Compress-Raw-Zlib-2.004.tar.gz
 Compress-Zlib-2.004.tar.gz
 Config-General-2.26.tar.gz
 CXC-Envs-0.59.tar.gz
-CXC-Envs-Flight-1.99.tar.gz
+CXC-Envs-Flight-2.01.tar.gz
 CXC-SysArch-1.00.tar.gz
 Data-DumpXML-1.06.tar.gz
 Data-ParseTable-0.06.tar.gz


### PR DESCRIPTION
This updates SYBASE to point to /soft/SYBASE15.7.
(minor version 2.00 skipped as used in testing for different update)