### PR TITLE
Remove virtualenv, virtualenvwrapper and stevedore

### DIFF
--- a/cfg/python_modules.cfg
+++ b/cfg/python_modules.cfg
@@ -23,7 +23,6 @@ modules:
   - name : six
   - name : pip
   - name : setuptools
-  - name : stevedore
   - name : pycrypto
     cmds :
       test    : |
@@ -80,9 +79,6 @@ modules:
     file : py-*
   - name : pytest
   - name : nose
-  - name : virtualenv
-    file : virtualenv-*
-  - name : virtualenvwrapper
   - name : mx
     file : egenix-mx-base*
   - name : Cython

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -72,14 +72,11 @@ Ska.tdb-0.3.tar.gz
 Ska.TelemArchive-0.08.tar.gz
 Sphinx-1.1.3.tar.gz
 Ska.quatutil-0.02.tar.gz
-stevedore-0.13.tar.gz
 tables-2.3.1.tar.gz
 tornado-2.1.1.tar.gz
 Cython-0.16.tar.gz
 Chandra.acis_esa-0.01.tar.gz
 Ska.report_ranges-0.01.tar.gz
-virtualenv-1.7.1.2.tar.gz
-virtualenvwrapper-3.6.tar.gz
 xija-0.3.4.tar.gz
 #
 # Testing and code validation


### PR DESCRIPTION
@jeanconn - do you have a problem with this?

 I checked and it appears the only thing using stevedore is virtualenvwrapper.

"checked" means grepping for stevedore in every *.py file in the CentOS-5 build directory.