### PR TITLE
Update xija and chandra_models

### DIFF
--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -9,7 +9,7 @@ asciitable-0.8.0.tar.gz
 autopep8-1.1.1.tar.gz
 BeautifulSoup-3.2.1.tar.gz
 chandra_aca-0.5.1.tar.gz
-chandra_models-0.6.tar.gz
+chandra_models-0.8.tar.gz
 #
 # Chandra namespace packages
 Chandra.cmd_states-0.9.2.tar.gz

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -59,7 +59,7 @@ Ska.TelemArchive-0.8.1.tar.gz
 Ska.quatutil-0.3.1.tar.gz
 #
 tables-2.3.1.tar.gz
-xija-0.5.tar.gz
+xija-0.7.tar.gz
 #
 # Testing and code validation
 #


### PR DESCRIPTION
Update xija and chandra_models.  This adds the roll support to xija for the updated dpa model and includes updated model specs in chandra_models.  HEAD/master is best served with its own PR for this as master has already diverged from the GRETA-appropriate candidate/build that includes these updates already.