### PR TITLE
Update mica to 0.5.3

### DIFF
--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -26,7 +26,7 @@ h5py-2.4.0.tar.gz
 hopper-0.1.tar.gz
 kadi-0.12.2.tar.gz
 matplotlib-1.4.3-local-qhull.tar.gz
-mica-0.5.2.tar.gz
+mica-0.5.3.tar.gz
 mpld3-0.2.tar.gz
 numexpr-2.2.2.tar.gz
 parse_cm-0.2.tar.gz


### PR DESCRIPTION
Update mica to 0.5.3

This gets the starcheck parsing for starcheck 11.6.