### PR TITLE
Remove --ignore-installed from pip install

### DIFF
--- a/cfg/python_modules.cfg
+++ b/cfg/python_modules.cfg
@@ -13,7 +13,7 @@ cmds :
     ${prefix_arch}/bin/python -c "import ${module}"
   install : |
     dot_pattern="\."
-    opt="--no-deps --verbose --ignore-installed --no-binary :all: --no-index"
+    opt="--no-deps --verbose --no-binary :all: --no-index"
     if [[ "${module}" =~ ${dot_pattern} ]]
     then
       # Namespace package, requires egg install


### PR DESCRIPTION
It appears that the `--ignore-installed` option is taken quite literally and the previous version is not removed.  This is potentially dangerous and also leaves the old egg-info file around, which ends up confusing `conda list`.  (And then messes up ska_testr understanding of what is installed).

There was a reason I put this there, but it might have been from past experience of having pip annoyingly refuse to install something, reporting that the dependency is already satisfied.

@jeanconn - thoughts?  My feeling is to go ahead with this until we discover a reason otherwise.