### PR TITLE
Add Crypt::SSLeay

### DIFF
--- a/cfg/perl_modules.cfg
+++ b/cfg/perl_modules.cfg
@@ -336,3 +336,4 @@ modules :
         # 2 tests don't seem to pass; we don't care at this time
         rm t/28exception.t
         env PYTHONHOME=${prefix_arch} make test
+  - name : Crypt::SSLeay

--- a/cfg/perl_modules.cfg
+++ b/cfg/perl_modules.cfg
@@ -337,3 +337,8 @@ modules :
         rm t/28exception.t
         env PYTHONHOME=${prefix_arch} make test
   - name : Crypt::SSLeay
+    cmds :
+      build : |
+         ${prefix_arch}/bin/perl Makefile.PL --default PREFIX=${prefix}/lib/perl LIB=${prefix}/lib/perl
+         make
+         make test

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -154,7 +154,7 @@ Clone-0.18.tar.gz
 Compress-Raw-Zlib-2.004.tar.gz
 Compress-Zlib-2.004.tar.gz
 Config-General-2.26.tar.gz
-Crypt-SSLeay-0.57.tar.gz
+Crypt-SSLeay-0.57_notestprompt.tar.gz
 CXC-Envs-0.59.tar.gz
 CXC-Envs-Flight-2.01.tar.gz
 CXC-SysArch-1.00.tar.gz

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -154,6 +154,7 @@ Clone-0.18.tar.gz
 Compress-Raw-Zlib-2.004.tar.gz
 Compress-Zlib-2.004.tar.gz
 Config-General-2.26.tar.gz
+Crypt-SSLeay-0.57.tar.gz
 CXC-Envs-0.59.tar.gz
 CXC-Envs-Flight-2.01.tar.gz
 CXC-SysArch-1.00.tar.gz


### PR DESCRIPTION
Add Crypt::SSLeay to support https URLs.

This is largely for https support in LWP::UserAgent for Replan Central.