### PR TITLE
Update mica to 3.9.0

### DIFF
--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -29,7 +29,7 @@ hopper-0.2.tar.gz
 kadi-3.13.0.tar.gz
 matplotlib-1.4.3-local-qhull.tar.gz
 maude-3.1.tar.gz
-mica-3.8.0.tar.gz
+mica-3.9.0.tar.gz
 mpld3-0.2.tar.gz
 nb2to3-3.1.tar.gz
 numexpr-2.2.2.tar.gz


### PR DESCRIPTION
Update mica to 3.9.0

This mica version includes updates to mica.starcheck to fix Py3 issues, adds the individual star acquisition probabilities from the starcheck output to the database, and implements enhancements to the kadi app that displays star information and star observation histories.