### PR TITLE
Update to kadi 3.14.0

### DIFF
--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -26,7 +26,7 @@ egenix-mx-base-3.0.0.tar.gz
 find_attitude-0.1.tar.gz
 h5py-2.4.0.tar.gz
 hopper-0.2.tar.gz
-kadi-3.13.0.tar.gz
+kadi-3.14.0.tar.gz
 matplotlib-1.4.3-local-qhull.tar.gz
 maude-3.1.tar.gz
 mica-3.9.2.tar.gz


### PR DESCRIPTION
Update to kadi 3.14.0 which includes the new break down of one shots per axis