### PR TITLE
Update startup 10_define_impska.py to use modern API

### DIFF
--- a/template/include/cfg/10_define_impska.py
+++ b/template/include/cfg/10_define_impska.py
@@ -1,14 +1,20 @@
+from IPython.core.magic import Magics, magics_class, line_magic
+from IPython import get_ipython
+
 ip = get_ipython()
 
 
-def import_ska(self, arg):
-    ip.ex('import asciitable')
-    ip.ex('import Ska.engarchive.fetch_eng as fetch')
-    ip.ex('from Chandra.Time import DateTime')
-    ip.ex('from Ska.Matplotlib import plot_cxctime, cxctime2plotdate')
-    ip.ex('from kadi import events')
-    ip.ex('from astropy.table import Table')
-    ip.ex('import numpy as np')
-    ip.ex('import matplotlib.pyplot as plt')
+@magics_class
+class MyMagics(Magics):
+    @line_magic
+    def impska(self, line):
+        ip.ex('import Ska.engarchive.fetch_eng as fetch')
+        ip.ex('from Chandra.Time import DateTime')
+        ip.ex('from Ska.Matplotlib import plot_cxctime, cxctime2plotdate')
+        ip.ex('from kadi import events')
+        ip.ex('from astropy.table import Table')
+        ip.ex('import numpy as np')
+        ip.ex('import matplotlib.pyplot as plt')
+        ip.ex('from Ska.tdb import msids')
 
-ip.define_magic('impska', import_ska)
+ip.register_magics(MyMagics)


### PR DESCRIPTION
This updates the startup template file `10_define_impska.py` to use the modern IPython API for doing this.  It is compatible with the current flight Ska IPython.

Testing: I have had this in my `profile_default/startup` since working on the Py3 branch.