### PR TITLE
Update agasc module to 3.5

### DIFF
--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -5,7 +5,7 @@
 Miniconda3-64-latest.tar.gz
 Miniconda-64-3.19.0.tar.gz
 Miniconda-32-3.19.0.tar.gz
-agasc-3.4.tar.gz
+agasc-3.5.tar.gz
 asciitable-0.8.0.tar.gz
 autopep8-1.1.1.tar.gz
 BeautifulSoup-3.2.1.tar.gz


### PR DESCRIPTION
Update agasc module to 3.5.  This version brings back support for use of different agasc files.