### PR TITLE
Update mica to 3.10.1 (vv bugfix)

### DIFF
--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -29,7 +29,7 @@ hopper-0.2.tar.gz
 kadi-3.13.0.tar.gz
 matplotlib-1.4.3-local-qhull.tar.gz
 maude-3.1.tar.gz
-mica-3.10.tar.gz
+mica-3.10.1.tar.gz
 mpld3-0.2.tar.gz
 nb2to3-3.1.tar.gz
 numexpr-2.2.2.tar.gz


### PR DESCRIPTION
This installs mica 3.10.1 which includes a fix to handle fewer than 8 image windows commanded/used during an observation.  The code was already set to handle windows removed during processing, but was not configured to handle an "uncommanded" slot/window.  The error caused by this bug is preventing vv processing from continuing, so this is a somewhat time critical patch.  An issue has been opened on mica https://github.com/sot/mica/issues/128 to update processing such that a similar error would not stop overall processing.