### PR TITLE
Add utility to prune old versions from /proj/sot/ska/pkgs

### DIFF
--- a/prune_packages.py
+++ b/prune_packages.py
@@ -1,0 +1,24 @@
+import re
+import glob
+import shutil
+from collections import defaultdict
+from distutils.version import LooseVersion
+
+# Max number of versions to keep
+N_KEEP = 2
+
+pkgs = defaultdict(list)
+
+files = glob.glob('/proj/sot/ska/pkgs/*.tar.gz')
+for f in files:
+    m = re.search(r'(.+)-([0-9.]+).tar.gz', f)
+    if m:
+        name, version = m.groups()
+        pkgs[name].append((version, f))
+
+
+for name, versions in pkgs.items():
+    versions = sorted(versions, key=lambda x: LooseVersion(x[0]))
+    for version, f in versions[:-N_KEEP]:
+        print('Moving {}'.format(f))
+        shutil.move(f, '/proj/sot/ska/pkgs/OLD/')

--- a/prune_packages.py
+++ b/prune_packages.py
@@ -1,3 +1,10 @@
+"""
+Prune old package versions from /proj/sot/ska/pkgs and put them into
+/proj/sot/ska/pkgs/OLD.
+
+Comment out the ``shutil.move`` line for a dry run.
+"""
+
 import re
 import glob
 import shutil
@@ -15,7 +22,6 @@ for f in files:
     if m:
         name, version = m.groups()
         pkgs[name].append((version, f))
-
 
 for name, versions in pkgs.items():
     versions = sorted(versions, key=lambda x: LooseVersion(x[0]))


### PR DESCRIPTION
This can help a bit with rsyncing packages to other installations.