### PR TITLE
Add cmd to save/export conda env to prefix_arch

### DIFF
--- a/cfg/anaconda-32.cfg
+++ b/cfg/anaconda-32.cfg
@@ -11,6 +11,7 @@ cmds :
   build   : |
     bash ./Miniconda-latest-Linux-x86.sh -b -p ${prefix_arch}
     ${prefix_arch}/bin/conda install --quiet --yes --no-update-dependencies --file=${installer_dir}/pkgs.conda
+    ${prefix_arch}/bin/conda-env export --name root > ${prefix_arch}/conda_env.yml
 
 modules:
   - name : python

--- a/cfg/anaconda-64.cfg
+++ b/cfg/anaconda-64.cfg
@@ -11,6 +11,7 @@ cmds :
   build   : |
     bash ./Miniconda-latest-Linux-x86_64.sh -b -p ${prefix_arch}
     ${prefix_arch}/bin/conda install --quiet --yes --no-update-dependencies --file=${installer_dir}/pkgs.conda
+    ${prefix_arch}/bin/conda-env export --name root > ${prefix_arch}/conda_env.yml
 
 modules:
   - name : python


### PR DESCRIPTION
Add cmd to save/export conda env to prefix_arch

This makes a yaml file that could be used to try to reproduce an environment (though actually using the file has not been thoroughly tested in skare).