### PR TITLE
Update mica to version 3.12

### DIFF
--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -29,7 +29,7 @@ hopper-0.2.tar.gz
 kadi-3.14.0.tar.gz
 matplotlib-1.4.3-local-qhull.tar.gz
 maude-3.1.tar.gz
-mica-3.11.tar.gz
+mica-3.12.tar.gz
 mpld3-0.2.tar.gz
 nb2to3-3.1.tar.gz
 numexpr-2.2.2.tar.gz


### PR DESCRIPTION
Mica 3.12 includes:

- new access to attitudes from mica.archive.asp_l1 via `get_atts` and `get_atts_from_files`.
- improvements to guide stats calculations
- new warnings for acquisition anomalies discovered in processing
- simplification of mica.reports