### PR TITLE
Update kadi from 3.14.1 to 3.15.2

### DIFF
--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -26,7 +26,7 @@ egenix-mx-base-3.0.0.tar.gz
 find_attitude-0.2.tar.gz
 h5py-2.4.0.tar.gz
 hopper-0.3.tar.gz
-kadi-3.14.1.tar.gz
+kadi-3.15.2.tar.gz
 matplotlib-1.4.3-local-qhull.tar.gz
 maude-3.1.tar.gz
 mica-3.14.0.tar.gz


### PR DESCRIPTION
At present this is for installing kadi 3.15 to Ska test.