### PR TITLE
Py3 catchup

### DIFF
--- a/cfg/python_modules.cfg
+++ b/cfg/python_modules.cfg
@@ -107,3 +107,7 @@ modules:
   - name : cxotime
 # - name : starcheck
   - name : testr
+  - name : acis_thermal_check
+  - name : psmc_check
+  - name : dpa_check
+  - name : dea_check

--- a/cfg/python_modules.cfg
+++ b/cfg/python_modules.cfg
@@ -111,3 +111,4 @@ modules:
   - name : psmc_check
   - name : dpa_check
   - name : dea_check
+  - name : acisfp_check

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -46,9 +46,9 @@ starcheck-11.22.tar.gz
 #
 # ACIS ops packages
 acis_thermal_check-2.1.0.tar.gz
-psmc_check-1.0.0.tar.gz
-dpa_check-2.0.0.tar.gz
-dea_check-2.0.0.tar.gz
+psmc_check-1.0.1.tar.gz
+dpa_check-2.1.0.tar.gz
+dea_check-2.0.1.tar.gz
 acisfp_check-2.0.0.tar.gz
 #
 # Ska namespace packages

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -45,7 +45,7 @@ ska_path-3.1.tar.gz
 starcheck-11.22.tar.gz
 #
 # ACIS ops packages
-acis_thermal_check-2.0.0.tar.gz
+acis_thermal_check-2.1.0.tar.gz
 psmc_check-1.0.0.tar.gz
 dpa_check-2.0.0.tar.gz
 dea_check-2.0.0.tar.gz

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -15,7 +15,7 @@ chandra_models-3.11.tar.gz
 # Chandra namespace packages
 Chandra.cmd_states-3.14.tar.gz
 Chandra.ECF-0.2.1.tar.gz
-Chandra.Maneuver-3.6.tar.gz
+Chandra.Maneuver-3.7.tar.gz
 Chandra.taco-0.2.1.tar.gz
 Chandra.Time-3.20.1.tar.gz
 #
@@ -25,7 +25,7 @@ Django-1.6.1.tar.gz
 egenix-mx-base-3.0.0.tar.gz
 find_attitude-0.2.tar.gz
 h5py-2.4.0.tar.gz
-hopper-0.2.tar.gz
+hopper-0.3.tar.gz
 kadi-3.14.1.tar.gz
 matplotlib-1.4.3-local-qhull.tar.gz
 maude-3.1.tar.gz
@@ -42,7 +42,7 @@ pyyaks-3.3.4.tar.gz
 Quaternion-3.4.1.tar.gz
 sherpa-4.7.tar.gz
 ska_path-3.1.tar.gz
-starcheck-11.22.tar.gz
+starcheck-11.23.tar.gz
 #
 # ACIS ops packages
 acis_thermal_check-2.1.0.tar.gz

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -49,6 +49,7 @@ acis_thermal_check-2.0.0.tar.gz
 psmc_check-1.0.0.tar.gz
 dpa_check-2.0.0.tar.gz
 dea_check-2.0.0.tar.gz
+acisfp_check-2.0.0.tar.gz
 #
 # Ska namespace packages
 Ska.arc5gl-3.1.1.tar.gz

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -45,10 +45,10 @@ ska_path-3.1.tar.gz
 starcheck-11.22.tar.gz
 #
 # ACIS ops packages
-acis_thermal_check-2.0.tar.gz
-psmc_check-1.0.tar.gz
+acis_thermal_check-2.0.0.tar.gz
+psmc_check-1.0.0.tar.gz
 dpa_check-2.0.0.tar.gz
-dea_check-2.0.tar.gz
+dea_check-2.0.0.tar.gz
 #
 # Ska namespace packages
 Ska.arc5gl-3.1.1.tar.gz

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -26,7 +26,7 @@ egenix-mx-base-3.0.0.tar.gz
 find_attitude-0.2.tar.gz
 h5py-2.4.0.tar.gz
 hopper-0.3.tar.gz
-kadi-3.14.1.tar.gz
+kadi-3.15.tar.gz
 matplotlib-1.4.3-local-qhull.tar.gz
 maude-3.1.tar.gz
 mica-3.14.0.tar.gz

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -44,6 +44,12 @@ sherpa-4.7.tar.gz
 ska_path-3.1.tar.gz
 starcheck-11.22.tar.gz
 #
+# ACIS ops packages
+acis_thermal_check-2.0.tar.gz
+psmc_check-1.0.tar.gz
+dpa_check-2.0.0.tar.gz
+dea_check-2.0.tar.gz
+#
 # Ska namespace packages
 Ska.arc5gl-3.1.1.tar.gz
 Ska.astro-3.2.1.tar.gz

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -15,7 +15,7 @@ chandra_models-3.11.tar.gz
 # Chandra namespace packages
 Chandra.cmd_states-3.14.tar.gz
 Chandra.ECF-0.2.1.tar.gz
-Chandra.Maneuver-3.7.tar.gz
+Chandra.Maneuver-3.6.tar.gz
 Chandra.taco-0.2.1.tar.gz
 Chandra.Time-3.20.1.tar.gz
 #


### PR DESCRIPTION
This brings the `py3` branch up to date with `master` and adds one more commit from #151 to install kadi 3.15.  In doing this I cherry-picked all the new non-merge commits.