### PR TITLE
ACIS updates for backstop history / nlet support

### DIFF
--- a/cfg/python_modules.cfg
+++ b/cfg/python_modules.cfg
@@ -131,6 +131,7 @@ modules:
   - name : cxotime
   - name : starcheck
   - name : testr
+  - name : backstop_history
   - name : acis_thermal_check
   - name : psmc_check
   - name : dpa_check

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -45,6 +45,7 @@ ska_path-3.1.tar.gz
 starcheck-11.23.tar.gz
 #
 # ACIS ops packages
+backstop_history-1.0.0.tar.gz
 acis_thermal_check-2.3.1.tar.gz
 psmc_check-1.1.0.tar.gz
 dpa_check-2.2.0.tar.gz

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -46,7 +46,7 @@ starcheck-11.23.tar.gz
 #
 # ACIS ops packages
 backstop_history-1.0.0.tar.gz
-acis_thermal_check-2.3.1.tar.gz
+acis_thermal_check-2.4.0.tar.gz
 psmc_check-1.1.0.tar.gz
 dpa_check-2.2.0.tar.gz
 dea_check-2.1.0.tar.gz


### PR DESCRIPTION
These are the module changes approved at load review on 15-Mar-2018.