### PR TITLE
Add acis_taco 4.0.  Replaces Chandra.taco, which will later be removed.

### DIFF
--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -19,6 +19,7 @@ Chandra.Maneuver-3.7.tar.gz
 Chandra.taco-0.2.1.tar.gz
 Chandra.Time-3.20.1.tar.gz
 #
+acis_taco-4.0.tar.gz
 cosmocalc-0.1.2.tar.gz
 cxotime-3.1.tar.gz
 Django-1.6.1.tar.gz


### PR DESCRIPTION
Making this a PR for better visibility.