### PR TITLE
Explicitly downgrade pycrypto to older/working 'build'

### DIFF
--- a/cfg/anaconda-32.cfg
+++ b/cfg/anaconda-32.cfg
@@ -11,6 +11,7 @@ cmds :
   build   : |
     bash ./Miniconda-latest-Linux-x86.sh -b -p ${prefix_arch}
     ${prefix_arch}/bin/conda install --quiet --yes --no-update-dependencies --file=${installer_dir}/pkgs.conda
+    ${prefix_arch}/bin/conda install pycrypto=2.6.1=py27_0
     ${prefix_arch}/bin/conda-env export --name root > ${prefix_arch}/conda_env.yml
 
 modules:

--- a/cfg/anaconda-32.cfg
+++ b/cfg/anaconda-32.cfg
@@ -11,7 +11,7 @@ cmds :
   build   : |
     bash ./Miniconda-latest-Linux-x86.sh -b -p ${prefix_arch}
     ${prefix_arch}/bin/conda install --quiet --yes --no-update-dependencies --file=${installer_dir}/pkgs.conda
-    ${prefix_arch}/bin/conda install pycrypto=2.6.1=py27_0
+    ${prefix_arch}/bin/conda install --quiet --yes --no-update-dependencies pycrypto=2.6.1=py27_0
     ${prefix_arch}/bin/conda-env export --name root > ${prefix_arch}/conda_env.yml
 
 modules:

--- a/cfg/anaconda-64.cfg
+++ b/cfg/anaconda-64.cfg
@@ -11,6 +11,7 @@ cmds :
   build   : |
     bash ./Miniconda-latest-Linux-x86_64.sh -b -p ${prefix_arch}
     ${prefix_arch}/bin/conda install --quiet --yes --no-update-dependencies --file=${installer_dir}/pkgs.conda
+    ${prefix_arch}/bin/conda install pycrypto=2.6.1=py27_0
     ${prefix_arch}/bin/conda-env export --name root > ${prefix_arch}/conda_env.yml
 
 modules:

--- a/cfg/anaconda-64.cfg
+++ b/cfg/anaconda-64.cfg
@@ -11,7 +11,7 @@ cmds :
   build   : |
     bash ./Miniconda-latest-Linux-x86_64.sh -b -p ${prefix_arch}
     ${prefix_arch}/bin/conda install --quiet --yes --no-update-dependencies --file=${installer_dir}/pkgs.conda
-    ${prefix_arch}/bin/conda install pycrypto=2.6.1=py27_0
+    ${prefix_arch}/bin/conda install --quiet --yes --no-update-dependencies pycrypto=2.6.1=py27_0
     ${prefix_arch}/bin/conda-env export --name root > ${prefix_arch}/conda_env.yml
 
 modules:


### PR DESCRIPTION
Explicitly downgrade pycrypto to older/working 'build'

This fixes Ska.ftp errors like:

```
>                   raise e
E                   ValueError: CTR mode needs counter parameter, not IV
```

Not sure if it makes sense to do this or to try to upgrade conda packages to get the newer version that also fixes this.  Thought this might be a reasonable minimal change.
