### PR TITLE
ACIS updates approved 31-Aug-2018

### DIFF
--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -27,7 +27,7 @@ egenix-mx-base-3.0.0.tar.gz
 find_attitude-0.2.tar.gz
 h5py-2.4.0.tar.gz
 hopper-0.3.tar.gz
-kadi-3.16.tar.gz
+kadi-3.16.1.tar.gz
 matplotlib-1.4.3-local-qhull.tar.gz
 maude-3.2.tar.gz
 mica-3.14.0.tar.gz

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -47,7 +47,7 @@ starcheck-11.26.tar.gz
 #
 # ACIS ops packages
 backstop_history-1.1.0.tar.gz
-acis_thermal_check-2.7.0.tar.gz
+acis_thermal_check-2.8.0.tar.gz
 psmc_check-1.2.0.tar.gz
 dpa_check-2.3.0.tar.gz
 dea_check-2.2.0.tar.gz

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -13,7 +13,7 @@ chandra_aca-3.22.tar.gz
 chandra_models-3.11.tar.gz
 #
 # Chandra namespace packages
-Chandra.cmd_states-3.14.tar.gz
+Chandra.cmd_states-3.14.2.tar.gz
 Chandra.ECF-0.2.1.tar.gz
 Chandra.Maneuver-3.7.tar.gz
 Chandra.taco-0.2.1.tar.gz


### PR DESCRIPTION
This includes changes to cmd_states and kadi to support that WSVIDALLDN sets ccd_count to 0.
There's also a new version of acis_thermal_check that uses the sqlite database by default instead of Sybase.