### PR TITLE
Post 2018:283 safe mode updates

### DIFF
--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -43,7 +43,7 @@ pyyaks-3.3.4.tar.gz
 Quaternion-3.4.1.tar.gz
 sherpa-4.7.tar.gz
 ska_path-3.1.tar.gz
-starcheck-11.28.tar.gz
+starcheck-11.29.tar.gz
 #
 # ACIS ops packages
 backstop_history-1.1.0.tar.gz

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -9,7 +9,7 @@ agasc-3.5.2.tar.gz
 asciitable-0.8.0.tar.gz
 autopep8-1.1.1.tar.gz
 BeautifulSoup-3.2.1.tar.gz
-chandra_aca-3.22.tar.gz
+chandra_aca-3.24.tar.gz
 chandra_models-3.21.tar.gz
 #
 # Chandra namespace packages

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -10,7 +10,7 @@ asciitable-0.8.0.tar.gz
 autopep8-1.1.1.tar.gz
 BeautifulSoup-3.2.1.tar.gz
 chandra_aca-3.22.tar.gz
-chandra_models-3.11.tar.gz
+chandra_models-3.21.tar.gz
 #
 # Chandra namespace packages
 Chandra.cmd_states-3.14.2.tar.gz

--- a/pkgs.manifest
+++ b/pkgs.manifest
@@ -75,7 +75,7 @@ Ska.quatutil-3.3.1.tar.gz
 tables-2.3.1.tar.gz
 tables3_api-0.1.tar.gz
 testr-3.2.tar.gz
-xija-3.10.tar.gz
+xija-3.12.tar.gz
 #
 # Testing and code validation
 #


### PR DESCRIPTION
This includes:
 - update to xija to support the ACA model with the time-step-power
 - update to chandra_aca with new drift model
 - update to chandra_models with the updated ACA model
 - update to starcheck to use the new ACA model